### PR TITLE
Run all GitHub actions on all OSs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,26 +22,11 @@ jobs:
                     - "ubuntu-22.04"
                     - "macos-10.15"
                     - "windows-2019"
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-            - uses: Swatinem/rust-cache@v2
-            - uses: extractions/setup-just@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - run: just build
-
-    just:
-        runs-on: ubuntu-22.04
-        strategy:
-            fail-fast: false
-            matrix:
                 just_cmd:
                     - "test"
                     - "check"
                     - "fix"
+                    - "build"
         steps:
             - uses: actions/checkout@v2
             - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
- Change the `just` job to run on all platforms
- Add `build` to the list of `just_cmd` commands
