### PR TITLE
Upgrade dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.69"
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { version = "4.1.6", features = ["derive"] }
 colored = "2.0.0"
 config = { version = "0.13.3", features = ["toml"] }
 dirs = "4.0.0"
@@ -28,7 +28,7 @@ regex = "1.7.1"
 reqwest = { version = "0.11.14", features = ["json", "gzip", "brotli", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0.152"
-serde_json = "1.0.92"
+serde_json = "1.0.93"
 simple_logger = "4.0.0"
 strum = "0.24.1"
 strum_macros = "0.24.3"


### PR DESCRIPTION
- Upgrade `clap` and `serde_json` to the latest versions

[Cargo.lock]
- Upgrade `clap` from version `4.1.4` to `4.1.6`
- Upgrade `serde_json` from version `1.0.92` to `1.0.93`
