### PR TITLE
fix: `git diff` flags for consistency

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -19,6 +19,8 @@ pub(crate) fn get_diffs() -> Result<String> {
             "--ignore-all-space",
             "--diff-algorithm=minimal",
             "--function-context",
+            "--no-ext-diff",
+            "--no-color",
         ],
     )?;
 


### PR DESCRIPTION
- Update git command in src/git.rs
- Remove the `ext-diff` flag and add the `no-color` flag to `git diff` command

Closes #97 