### PR TITLE
feat: Add OpenAI API settings to project.

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fs, path::PathBuf, str::FromStr};
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::prelude::PermissionsExt};
 
+use async_openai::API_BASE;
 use config::{
     builder::DefaultState, Config, ConfigBuilder, ConfigError, Environment, File, Source,
 };
@@ -223,7 +224,7 @@ impl Settings {
             .set_default(
                 "openai",
                 Some(OpenAISettings {
-                    api_base: None,
+                    api_base: Some(API_BASE.to_string()),
                     api_key: None,
                     model: Some(DEFAULT_OPENAI_MODEL.to_string()),
                     retries: Some(2),


### PR DESCRIPTION
- Import and integrate the `async_openai` module with `API_BASE` constant
