### PR TITLE
Remove prefix format for better flexibility

### DIFF
--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -104,7 +104,7 @@ impl SummarizationClient {
 
         let mut message = self.commit_translate(&message).await?;
         if !conventional_commit_prefix.is_empty() {
-            message.insert_str(0, &format!("{conventional_commit_prefix}: "));
+            message.insert_str(0, conventional_commit_prefix.as_str());
         }
 
         Ok(message)


### PR DESCRIPTION
Enhance the prefix by removing `:` to expand its applicability, such as in case #115.