### PR TITLE
Add Bedrock, Ollama, Claude2, Cohere, Replicate [100+ LLMs] - using LiteLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,28 @@ To maintain compatibility with other OpenAI clients, we support the `OPENAI_API_
 gptcommit config set openai.model text-davinci-002
 ```
 
+### Try out Anthropic,Huggingface,Palm,Ollama, etc.[Full List](https://docs.litellm.ai/docs/providers)
+
+#### Create OpenAI-proxy
+We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
+
+```python
+pip install litellm
+```
+```python
+$ litellm --model ollama/codellama
+
+#INFO: Ollama running on http://0.0.0.0:8000
+```
+
+[Docs](https://docs.litellm.ai/docs/proxy_server)
+
+#### Update GPTCommit
+
+```sh
+gptcommit config set --local openai.api_base http://0.0.0.0:8000
+```
+
 You can also config this setting via the `GPTCOMMIT__OPENAI__MODEL`.
 
 For a list of public OpenAI models, checkout the [OpenAI docs](https://beta.openai.com/docs/models/overview). You can also bring in your own fine-tuned model.


### PR DESCRIPTION
Hi @zurawiki,

Noticed you're calling the openai completions endpoint. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and wanted to see how i could be helpful.

My PR shows users how to call their LLM providers (bedrock, togetherai, huggingface tgi, replicate, ai21, cohere, ai21 etc.) by pointing your openai endpoint to a [local proxy](https://docs.litellm.ai/docs/proxy_server) they can use for experimentation.

This makes **no code changes** to your app.

Happy to add additional tests/documentation if the initial PR looks good.