### PR TITLE
feat: support direct generate commit msg by pipe diff

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 pub(crate) struct GptcommitCLI {
     /// The action to perform (subcommand).
     #[command(subcommand)]
-    pub action: Action,
+    pub action: Option<Action>,
     /// Enable verbose logging.
     #[arg(short, long, global = true)]
     pub verbose: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,13 @@ mod summarize;
 mod toml;
 mod util;
 
+use crate::actions::prepare_commit_msg::generate_commit_message;
 use anyhow::Result;
 use clap::Parser;
 use log::LevelFilter;
 use settings::Settings;
 use simple_logger::SimpleLogger;
+use std::io::Read;
 
 use crate::cli::Action;
 
@@ -39,12 +41,23 @@ async fn main() -> Result<()> {
     let settings = Settings::new()?;
     debug!("Settings: {:?}", settings);
 
-    match cli_args.action {
-        Action::Config(cli_args) => actions::config::main(settings, cli_args).await,
-        Action::Install => actions::install::main(settings).await,
-        Action::Uninstall => actions::uninstall::main(settings).await,
-        Action::PrepareCommitMsg(cli_args) => {
-            actions::prepare_commit_msg::main(settings, cli_args).await
+    if let Some(subcommand) = cli_args.action {
+        match subcommand {
+            Action::Config(cli_args) => actions::config::main(settings, cli_args).await,
+            Action::Install => actions::install::main(settings).await,
+            Action::Uninstall => actions::uninstall::main(settings).await,
+            Action::PrepareCommitMsg(cli_args) => {
+                actions::prepare_commit_msg::main(settings, cli_args).await
+            }
         }
+    } else {
+        let stdin = std::io::stdin();
+        let mut buffer = String::new();
+        let mut handle = stdin.lock();
+
+        handle.read_to_string(&mut buffer)?;
+        let commit_msg = generate_commit_message(&settings, &buffer).await?;
+        print!("{commit_msg}");
+        Ok(())
     }
 }


### PR DESCRIPTION
sometimes it's handy to use `git commit -am "$(git diff --cached | gptcommit)"` than install hook
