### PR TITLE
Use gpt-4.1-nano by default

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,8 +1,8 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
 
 repository:
-  description: A git prepare-commit-msg hook for authoring commit messages with GPT-3.
-  topics: git rust cli githook large-language-models gpt3 commit-message
+  description: A git prepare-commit-msg hook for authoring commit messages with OpenAI.
+  topics: git rust cli githook large-language-models commit-message
   has_issues: true
   has_projects: false
   has_wiki: false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![crates.io downloads](https://img.shields.io/crates/d/gptcommit.svg)](https://crates.io/crates/gptcommit)
 [![Rust dependency status](https://deps.rs/repo/github/zurawiki/gptcommit/status.svg)](https://deps.rs/repo/github/zurawiki/gptcommit)
 
-A git prepare-commit-msg hook for authoring commit messages with GPT-3. With this tool, you can easily generate clear, comprehensive and descriptive commit messages letting you focus on writing code.
+A git prepare-commit-msg hook for authoring commit messages with an OpenAI language model. With this tool, you can easily generate clear, comprehensive and descriptive commit messages letting you focus on writing code.
 
 See [announcement blog post](https://zura.wiki/post/never-write-a-commit-message-again-with-the-help-of-gpt-3/).
 
@@ -40,7 +40,7 @@ gptcommit install
 
 To use `gptcommit`, simply run `git commit` as you normally would. The hook will automatically generate a commit message for you using a large language model like GPT. If you're not satisfied with the generated message, you can always edit it before committing.
 
-Note: By default, `gptcommit` uses the GPT-3 model. Please ensure you have sufficient credits in your OpenAI account to use it.
+Note: By default, `gptcommit` uses the fastest and most cost-effective OpenAI model available. Please ensure you have sufficient credits in your OpenAI account to use it.
 
 ## Features
 
@@ -91,10 +91,10 @@ To maintain compatibility with other OpenAI clients, we support the `OPENAI_API_
 
 ### Try out a different OpenAI model
 
-`gptcommit` uses `text-davinci-003` by default. The model can be configured to use other models as below
+`gptcommit` uses a cost-effective default model. The model can be configured to use other models as below
 
 ```sh
-gptcommit config set openai.model text-davinci-002
+gptcommit config set openai.model your-model-name
 ```
 
 You can also config this setting via the `GPTCOMMIT__OPENAI__MODEL`.

--- a/package/winget/zurawiki.gptcommit.locale.en-US.yaml
+++ b/package/winget/zurawiki.gptcommit.locale.en-US.yaml
@@ -9,7 +9,7 @@ PackageName: gptcommit
 PackageUrl: https://github.com/zurawiki/gptcommit
 License: MIT
 LicenseUrl: https://github.com/zurawiki/gptcommit/blob/main/LICENSE
-ShortDescription: A git prepare-commit-msg hook for authoring commit messages with GPT-3
+ShortDescription: A git prepare-commit-msg hook for authoring commit messages with OpenAI
 Tags:
   - "console"
   - "command-line"

--- a/prompts/conventional_commit.tera
+++ b/prompts/conventional_commit.tera
@@ -1,9 +1,6 @@
-You are an expert programmer summarizing a code change.
-You went over every file that was changed in it.
-For some of these files changes where too big and were omitted in the files diff summary.
-Determine the best label for the commit.
+You are an expert programmer determining the best conventional commit label for the following change.
 
-Here are the labels you can choose from:
+Choose one of the following labels:
 
 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - chore: Updating libraries, copyrights or other repo setting, includes updating dependencies.
@@ -22,4 +19,4 @@ THE FILE SUMMARIES:
 {{ summary_points }}
 ###
 
-The label best describing this change:
+Respond with only the label best describing this change:

--- a/prompts/summarize_commit.tera
+++ b/prompts/summarize_commit.tera
@@ -1,17 +1,13 @@
-You are an expert programmer writing a commit message.
-You went over every file that was changed in it.
-For some of these files changes where too big and were omitted in the files diff summary.
-Please summarize the commit.
-Write your response in bullet points, using the imperative tense.
-Starting each bullet point with a `-`.
-Write a high level description. Do not repeat the commit summaries or the file summaries.
-Write the most important bullet points. The list should not be more than a few bullet points.
+You are an expert programmer writing a concise commit summary.
+Summarize the overall change in a handful of short bullet points.
+Use the imperative mood and begin each bullet with `-`.
+Focus on high level actions, avoiding repetition of file summaries.
+Return no more than five bullet points.
 
 THE FILE SUMMARIES:
 ```
 {{ summary_points }}
 ```
 
-Remember to write only the most important points and do not write more than a few bullet points.
 
 THE COMMIT MESSAGE:

--- a/prompts/summarize_file_diff.tera
+++ b/prompts/summarize_file_diff.tera
@@ -1,44 +1,9 @@
-You are an expert programmer summarizing a git diff.
-Reminders about the git diff format:
-For every file, there are a few metadata lines, like (for example):
-```
-diff --git a/lib/index.js b/lib/index.js
-index aadf691..bfef603 100644
---- a/lib/index.js
-+++ b/lib/index.js
-```
-This means that `lib/index.js` was modified in this commit. Note that this is only an example.
-Then there is a specifier of the lines that were modified.
-A line starting with `+` means it was added.
-A line that starting with `-` means that line was deleted.
-A line that starts with neither `+` nor `-` is code given for context and better understanding.
-It is not part of the diff.
-After the git diff of the first file, there will be an empty line, and then the git diff of the next file.
-
-Do not include the file name as another part of the comment.
-Do not use the characters `[` or `]` in the summary.
-Write every summary comment in a new line.
-Comments should be in a bullet point list, each line starting with a `-`.
-The summary should not include comments copied from the code.
-The output should be easily readable. When in doubt, write fewer comments and not more. Do not output comments that
-simply repeat the contents of the file.
-Readability is top priority. Write only the most important comments about the diff.
-
-EXAMPLE SUMMARY COMMENTS:
-```
-- Raise the amount of returned recordings from `10` to `100`
-- Fix a typo in the github action name
-- Move the `octokit` initialization to a separate file
-- Add an OpenAI API for completions
-- Lower numeric tolerance for test files
-- Add 2 tests for the inclusive string split function
-```
-Most commits will have less comments than this examples list.
-The last comment does not include the file names,
-because there were more than two relevant files in the hypothetical commit.
-Do not include parts of the example in your summary.
-It is given only as an example of appropriate comments.
-
+You are an expert programmer summarizing the following git diff.
+Produce concise bullet points describing the key changes.
+List at most five points for brevity.
+Use the imperative mood and start each line with `-`.
+Exclude file names, diff markers and code snippets.
+Keep the summary short and easy to read.
 
 THE GIT DIFF TO BE SUMMARIZED:
 ```

--- a/prompts/title_commit.tera
+++ b/prompts/title_commit.tera
@@ -1,11 +1,6 @@
-You are an expert programmer writing a commit message title.
-You went over every file that was changed in it.
-Some of these files changes were too big, and were omitted in the summaries below.
-Please summarize the commit into a single specific and cohesive theme.
-Write your response using the imperative tense following the kernel git commit style guide.
-Write a high level title.
-Do not repeat the commit summaries or the file summaries.
-Do not list individual changes in the title.
+You are an expert programmer generating a concise commit title.
+Summarize the change in a single short sentence using the imperative mood.
+Ignore file names and diff details.
 
 EXAMPLE SUMMARY COMMENTS:
 ```
@@ -20,5 +15,6 @@ THE FILE SUMMARIES:
 {{ summary_points }}
 ```
 
-Remember to write only one line, no more than 50 characters.
+Write only one line, no more than 50 characters.
+Respond with just the title text.
 THE COMMIT MESSAGE TITLE:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -22,7 +22,8 @@ use crate::{
     },
 };
 
-static DEFAULT_OPENAI_MODEL: &str = "gpt-3.5-turbo-16k";
+// Use the fastest and cheapest model available by default
+static DEFAULT_OPENAI_MODEL: &str = "gpt-4.1-nano";
 
 static DEFAULT_FILES_TO_IGNORE: &[&str; 8] = &[
     "bun.lockb",

--- a/tests/e2e/test_config_list_get_set.sh
+++ b/tests/e2e/test_config_list_get_set.sh
@@ -6,7 +6,7 @@ gptcommit config list
 gptcommit config keys
 
 gptcommit config get openai.model
-# assert default = text-davinci-003
+# assert default = gpt-4.1-nano
 gptcommit config set openai.model foo
 gptcommit config get openai.model
 # assert is foo

--- a/tests/e2e/test_config_local_list_get_set.sh
+++ b/tests/e2e/test_config_local_list_get_set.sh
@@ -10,7 +10,7 @@ export TEMPDIR=$(mktemp -d)
     # assert is valid TOML
 
     gptcommit config get openai.model
-    # assert default = text-davinci-003
+    # assert default = gpt-4.1-nano
     gptcommit config set --local openai.model foo
     gptcommit config set openai.model bar
     gptcommit config get openai.model
@@ -34,7 +34,7 @@ export TEMPDIR=$(mktemp -d)
     # assert is valid TOML
 
     gptcommit config get openai.model
-    # assert default = text-davinci-003
+    # assert default = gpt-4.1-nano
     set +e
     gptcommit config set --local openai.model foo
     # TODO assert output


### PR DESCRIPTION
## Summary
- use the fastest model `gpt-4.1-nano` by default
- tweak prompts for concise responses
- remove hard-coded model names from docs and metadata
- fix wording in repo metadata

## Testing
- `cargo test` *(fails: failed to download crates)*
- `sh -x tests/e2e/test_config_list_get_set.sh` *(fails: `gptcommit: not found`)*
- `sh -x tests/e2e/test_config_local_list_get_set.sh` *(fails: `gptcommit: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68300130a5908326914cdf76ef4c2729