### PR TITLE
Fix CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,9 @@ jobs:
                   export EXIT_CODE="$?"
                   set -e
                   if [[ "$EXIT_CODE" == "7" ]]; then
-                    echo '::set-output name=is_new_version::no'
+                    echo "is_new_version=no" >> $GITHUB_OUTPUT
                   elif [[ "$EXIT_CODE" == "0" ]]; then
-                    echo '::set-output name=is_new_version::yes'
+                    echo "is_new_version=yes" >> $GITHUB_OUTPUT
                   else
                     # Unexpected outcome, indicates a bug.
                     exit "$EXIT_CODE"

--- a/scripts/is_version_already_uploaded.sh
+++ b/scripts/is_version_already_uploaded.sh
@@ -24,8 +24,9 @@ echo >&2 "Crate $CRATE_NAME current version: $CURRENT_VERSION"
 # on substrings of versions.
 EXISTING_VERSIONS="
 $( \
-    curl 2>/dev/null "https://crates.io/api/v1/crates/$CRATE_NAME" | \
-    jq --exit-status -r .versions[].num \
+    curl 2>/dev/null -H "User-Agent: gptcommit-ci (https://github.com/zurawiki/gptcommit)" \
+        "https://crates.io/api/v1/crates/$CRATE_NAME" | \
+    jq --exit-status -r '(.versions // []) | .[].num' \
 )"
 echo >&2 -e "Versions on crates.io:$EXISTING_VERSIONS\n"
 

--- a/src/actions/prepare_commit_msg.rs
+++ b/src/actions/prepare_commit_msg.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use clap::arg;
 use clap::ValueEnum;
 use colored::Colorize;
 


### PR DESCRIPTION
### Why

CI has been broken on all recent runs due to three issues: an unused import triggering clippy errors, deprecated `::set-output` syntax in the workflow, and the crates.io version check script failing because it lacks a User-Agent header (required by crates.io policy).

### Test plan

- Verify all CI jobs pass on this PR (lint, build & test on Linux/macOS/Windows, version check)